### PR TITLE
Mate not displayed after pawn move

### DIFF
--- a/angular-chess/src/app/services/move-execution.service.ts
+++ b/angular-chess/src/app/services/move-execution.service.ts
@@ -74,7 +74,7 @@ export class MoveExecutionService {
   }
 
   private finishMove(move: Move): void {
-    if (!(move.piece.type === PieceType.PAWN && Math.abs(move.from.row - move.to.row) === 2)) {
+    if (!this.hasPawnGoneLongStep(move)) {
       this.boardService.clearEnPassantSquares();
     }
 
@@ -93,6 +93,10 @@ export class MoveExecutionService {
         this.boardService.updateResult(move.piece.color === Color.WHITE ? Result.WHITE_WIN : Result.BLACK_WIN);
       }
     }
+  }
+
+  private hasPawnGoneLongStep(move: Move): boolean {
+    return move.piece.type === PieceType.PAWN && Math.abs(move.from.row - move.to.row) === 2;
   }
 
   private isCastle(move: Move): boolean | undefined {

--- a/angular-chess/src/app/services/move-execution.service.ts
+++ b/angular-chess/src/app/services/move-execution.service.ts
@@ -74,6 +74,10 @@ export class MoveExecutionService {
   }
 
   private finishMove(move: Move): void {
+    if (!(move.piece.type === PieceType.PAWN && Math.abs(move.from.row - move.to.row) === 2)) {
+      this.boardService.clearEnPassantSquares();
+    }
+
     if (!(move.isShortCastle || move.isLongCastle)) {
       this.movePiece(move);
     }
@@ -88,11 +92,6 @@ export class MoveExecutionService {
       if (move.isMate) {
         this.boardService.updateResult(move.piece.color === Color.WHITE ? Result.WHITE_WIN : Result.BLACK_WIN);
       }
-    }
-
-
-    if (!(move.piece.type === PieceType.PAWN && Math.abs(move.from.row - move.to.row) === 2)) {
-      this.boardService.clearEnPassantSquares();
     }
   }
 

--- a/angular-chess/src/app/services/move-execution.service.ts
+++ b/angular-chess/src/app/services/move-execution.service.ts
@@ -78,7 +78,7 @@ export class MoveExecutionService {
       this.boardService.clearEnPassantSquares();
     }
 
-    if (!(move.isShortCastle || move.isLongCastle)) {
+    if (!(this.isCastle(move))) {
       this.movePiece(move);
     }
 
@@ -93,6 +93,10 @@ export class MoveExecutionService {
         this.boardService.updateResult(move.piece.color === Color.WHITE ? Result.WHITE_WIN : Result.BLACK_WIN);
       }
     }
+  }
+
+  private isCastle(move: Move): boolean | undefined {
+    return move.isShortCastle || move.isLongCastle;
   }
 
   private capturePiece(move: Move): void {


### PR DESCRIPTION
- en passant squares will now be cleared first when finishing a move
- see https://github.com/RubikNube/angular-chess/issues/3 for description of the problem