### PR TITLE
14_support_pawn_promotion

### DIFF
--- a/angular-chess/src/app/app.module.ts
+++ b/angular-chess/src/app/app.module.ts
@@ -4,6 +4,8 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ButtonModule } from 'primeng/button';
 import { DragDropModule } from 'primeng/dragdrop';
+import { ListboxModule } from 'primeng/listbox';
+import { OverlayPanelModule } from 'primeng/overlaypanel';
 import { SplitterModule } from "primeng/splitter";
 import { TableModule } from 'primeng/table';
 import { ToastModule } from 'primeng/toast';
@@ -25,7 +27,9 @@ import { MoveHistoryComponent } from './components/move-history/move-history.com
     SplitterModule,
     TableModule,
     ToastModule,
-    BrowserAnimationsModule
+    BrowserAnimationsModule,
+    OverlayPanelModule,
+    ListboxModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/angular-chess/src/app/components/chess-board.component.html
+++ b/angular-chess/src/app/components/chess-board.component.html
@@ -21,6 +21,15 @@
   ></div>
 </div>
 
+<p-overlayPanel #op>
+  <ng-template pTemplate>
+    <p-listbox
+      [options]="possiblePromotionPieces"
+      (onClick)="selectPromotionPiece($event)"
+    ></p-listbox>
+  </ng-template>
+</p-overlayPanel>
+
 <div class="p-inputgroup board-btn-group">
   <div class="{{this.boardService.getPlayerToMove$()|async}}-playerToMove"></div>
   <div class="result">{{getResultRepresentation(this.boardService.getResult$()|async)}}</div>
@@ -44,6 +53,12 @@
     pRipple
     label="Import FEN"
     (click)="this.boardService.importFen(fen.value)"
+  ></button>
+  <button
+    type="text"
+    pButton
+    label="Basic"
+    (click)="op.toggle($event)"
   ></button>
 </div>
 

--- a/angular-chess/src/app/components/chess-board.component.html
+++ b/angular-chess/src/app/components/chess-board.component.html
@@ -54,12 +54,6 @@
     label="Import FEN"
     (click)="this.boardService.importFen(fen.value)"
   ></button>
-  <button
-    type="text"
-    pButton
-    label="Basic"
-    (click)="op.toggle($event)"
-  ></button>
 </div>
 
 <p-toast position="top-center"></p-toast>

--- a/angular-chess/src/app/services/move-execution.service.ts
+++ b/angular-chess/src/app/services/move-execution.service.ts
@@ -111,14 +111,14 @@ export class MoveExecutionService {
       this.boardService.removePiece(move.capturedPiece);
     }
     move.piece.position = move.to;
-    this.boardService.addPiece(move.piece);
+    this.boardService.addPiece(move.promotedPiece ? move.promotedPiece : move.piece);
   }
 
   private movePiece(move: Move): void {
     console.log("movePiece: " + JSON.stringify(move));
     this.boardService.removePiece(move.piece);
     move.piece.position = move.to;
-    this.boardService.addPiece(move.piece);
+    this.boardService.addPiece(move.promotedPiece ? move.promotedPiece : move.piece);
   }
 
   private executeLongCastle(move: Move): void {

--- a/angular-chess/src/app/types/pieces.t.ts
+++ b/angular-chess/src/app/types/pieces.t.ts
@@ -25,6 +25,7 @@ export type Move = {
   isLongCastle?: boolean;
   isCheck?: boolean;
   isMate?: boolean;
+  promotedPiece?: Piece;
 }
 
 export type FullMove = {


### PR DESCRIPTION
- see https://github.com/RubikNube/angular-chess/issues/14
- added dropdown for promotion
- TODO: add check for check/mate after promotion

Steps to open promotion:

1. load FEN "2k5/6P1/8/8/8/8/1p6/4K3 w - - 0 1"
2. move white pawn to 8th row
3. move black pawn to 1st row

Current state:
![image](https://user-images.githubusercontent.com/25728708/151454625-052eb277-14ec-40cc-b8c4-605cdaea9c66.png)
