### PR TITLE
14_pawn_promotion_history

### DIFF
--- a/angular-chess/src/app/components/move-history/move-history.component.html
+++ b/angular-chess/src/app/components/move-history/move-history.component.html
@@ -22,10 +22,18 @@
       <td>
         <div class="chess-motif">{{getPieceChar(fullMove?.whiteMove)}}</div>
         {{getMoveRepresentation(fullMove?.whiteMove)}}
+        <div
+          *ngIf="fullMove?.whiteMove?.promotedPiece"
+          class="chess-motif"
+        >{{this.getPromotionRepresentation(fullMove?.whiteMove)}}</div>
       </td>
       <td>
         <div class="chess-motif">{{getPieceChar(fullMove?.blackMove)}}</div>
         {{getMoveRepresentation(fullMove?.blackMove)}}
+        <div
+          *ngIf="fullMove?.blackMove?.promotedPiece"
+          class="chess-motif"
+        >{{this.getPromotionRepresentation(fullMove?.blackMove)}}</div>
       </td>
     </tr>
   </ng-template>

--- a/angular-chess/src/app/components/move-history/move-history.component.ts
+++ b/angular-chess/src/app/components/move-history/move-history.component.ts
@@ -35,6 +35,11 @@ export class MoveHistoryComponent {
     }
   }
 
+
+  public getPromotionRepresentation(move: Move): string {
+    return move.promotedPiece ? "=" + PieceUtils.getPieceChar(move.promotedPiece.type, move.promotedPiece.color) : "";
+  }
+
   public getPieceChar(move: Move): string {
     if (move === undefined) {
       return "";


### PR DESCRIPTION
- added move representation for promotion of pieces

Steps to reproduce:

1. load FEN "4k3/7P/8/8/8/8/1p6/4K3 b - - 0 1"
2. promote pawns

![image](https://user-images.githubusercontent.com/25728708/151679000-4c2f3d12-9698-4eea-8a48-e7fbb518bd82.png)
