### PR TITLE
35-feature-new-button-or-option-to-close-the-move-history-area

### DIFF
--- a/angular-chess/src/app/app.component.html
+++ b/angular-chess/src/app/app.component.html
@@ -1,10 +1,16 @@
 <app-main-menu></app-main-menu>
 
-<p-splitter class="background">
-  <ng-template pTemplate>
-    <app-chess-board></app-chess-board>
-  </ng-template>
-  <ng-template pTemplate>
-    <app-move-history></app-move-history>
-  </ng-template>
-</p-splitter>
+<ng-template [ngIf]="this.moveHistoryService.showMoveHistory$|async">
+  <p-splitter class="background">
+    <ng-template pTemplate>
+      <app-chess-board></app-chess-board>
+    </ng-template>
+    <ng-template pTemplate>
+      <app-move-history></app-move-history>
+    </ng-template>
+  </p-splitter>
+</ng-template>
+
+<ng-template [ngIf]="!(this.moveHistoryService.showMoveHistory$|async)">
+  <app-chess-board></app-chess-board>
+</ng-template>

--- a/angular-chess/src/app/app.component.ts
+++ b/angular-chess/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { MoveHistoryService } from './services/move-history.service';
 
 @Component({
   selector: 'app-root',
@@ -6,4 +7,6 @@ import { Component } from '@angular/core';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
+  constructor(public moveHistoryService: MoveHistoryService) {
+  }
 }

--- a/angular-chess/src/app/components/chess-board.component.scss
+++ b/angular-chess/src/app/components/chess-board.component.scss
@@ -1,7 +1,9 @@
+$board-width: 80vh;
+
 div.board {
   margin: auto;
-  width: 80vh;
-  height: 80vh;
+  width: $board-width;
+  height: $board-width;
   display: grid;
   grid-template-columns: repeat(8, auto);
   grid-template-rows: repeat(8, auto);
@@ -21,12 +23,16 @@ div.board {
 }
 
 .playerToMove {
-  width: 100%;
+  width: $board-width;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 5px;
   height: 3em;
   display: flex;
   align-items: center;
   justify-content: center;
   font-weight: bold;
+  color: #495057;
 
   &-color--WHITE {
     background-color: white;

--- a/angular-chess/src/app/components/chess-board.component.scss
+++ b/angular-chess/src/app/components/chess-board.component.scss
@@ -1,5 +1,5 @@
 div.board {
-  margin: 0.5vw 0;
+  margin: auto;
   width: 80vh;
   height: 80vh;
   display: grid;

--- a/angular-chess/src/app/components/chess-board.component.ts
+++ b/angular-chess/src/app/components/chess-board.component.ts
@@ -52,8 +52,6 @@ export class ChessBoardComponent implements OnInit {
     private messageService: MessageService,
     private moveHistoryService: MoveHistoryService
   ) {
-    this.boardService.importFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq");
-
     this.isDragDisabled$$ = new BehaviorSubject<boolean>(false);
     this.isDragDisabled$ = this.isDragDisabled$$.asObservable();
 

--- a/angular-chess/src/app/components/main-menu/main-menu.component.ts
+++ b/angular-chess/src/app/components/main-menu/main-menu.component.ts
@@ -2,9 +2,10 @@ import { Clipboard } from '@angular/cdk/clipboard';
 import { Component } from '@angular/core';
 import { MenuItem, MessageService, PrimeIcons } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { ChessBoardService } from 'src/app/services/chess-board.service';
-import { PositioningService } from 'src/app/services/positioning.service';
 import { BoardThemingService } from 'src/app/services/board-theming.service';
+import { ChessBoardService } from 'src/app/services/chess-board.service';
+import { MoveHistoryService } from 'src/app/services/move-history.service';
+import { PositioningService } from 'src/app/services/positioning.service';
 import BoardUtils from 'src/app/utils/board.utils';
 import { ImportFenComponent } from './import-fen/import-fen.component';
 
@@ -18,10 +19,37 @@ export class MainMenuComponent {
   public menuItems: MenuItem[];
   private ref: DynamicDialogRef | undefined;
 
+  private showHistoryItem: MenuItem = {
+    id: 'show-history',
+    label: 'Show move history',
+    icon: PrimeIcons.LIST,
+    command: () => this.moveHistoryService.showMoveHistory()
+  };
+
+  private hideHistoryItem: MenuItem = {
+    id: 'hide-history',
+    label: 'Hide move history',
+    icon: PrimeIcons.LIST,
+    command: () => this.moveHistoryService.hideMoveHistory()
+  };
+
+  private viewItems: MenuItem[] = [{
+    label: 'Switch Board',
+    icon: PrimeIcons.SYNC,
+    command: () => this.positioningService.switchPerspective()
+  }, {
+    label: 'Toggle board theme',
+    icon: PrimeIcons.MICROSOFT,
+    command: () => this.themingService.toggleTheme()
+  },
+  this.showHistoryItem,
+  this.hideHistoryItem];
+
   constructor(
     private boardService: ChessBoardService,
     private positioningService: PositioningService,
     private themingService: BoardThemingService,
+    private moveHistoryService: MoveHistoryService,
     public dialogService: DialogService,
     public messageService: MessageService,
     private clipboard: Clipboard
@@ -39,17 +67,20 @@ export class MainMenuComponent {
       {
         label: 'View',
         icon: PrimeIcons.EYE,
-        items: [{
-          label: 'Switch Board',
-          icon: PrimeIcons.SYNC,
-          command: () => this.positioningService.switchPerspective()
-        }, {
-          label: 'Toggle board theme',
-          icon: PrimeIcons.MICROSOFT,
-          command: () => this.themingService.toggleTheme()
-        }]
+        items: this.viewItems
       }
-    ];
+    ];;
+
+    this.moveHistoryService.showMoveHistory$.subscribe(showHistory => {
+      if (showHistory) {
+        this.hideHistoryItem.visible = true;
+        this.showHistoryItem.visible = false;
+      }
+      else {
+        this.showHistoryItem.visible = true;
+        this.hideHistoryItem.visible = false;
+      }
+    });
   }
 
   private resetBoard(): void {

--- a/angular-chess/src/app/services/chess-board.service.ts
+++ b/angular-chess/src/app/services/chess-board.service.ts
@@ -32,6 +32,7 @@ export class ChessBoardService {
   private fen$$: BehaviorSubject<string> = new BehaviorSubject("");
 
   constructor(private moveHistoryService: MoveHistoryService) {
+    this.importFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq");
   }
 
   public updateResult(result: Result) {

--- a/angular-chess/src/app/services/move-history.service.ts
+++ b/angular-chess/src/app/services/move-history.service.ts
@@ -11,6 +11,9 @@ export class MoveHistoryService {
   private moveHistory$$: BehaviorSubject<Move[]> = new BehaviorSubject<Move[]>([]);
   private moveHistory$: Observable<Move[]> = this.moveHistory$$.asObservable();
 
+  private showMoveHistory$$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
+  public showMoveHistory$: Observable<boolean> = this.showMoveHistory$$.asObservable();
+
   private fullMoveHistory$: Observable<FullMove[]> = this.createFullMoveHistory$();
 
   public addMoveToHistory(move: Move): void {
@@ -76,5 +79,13 @@ export class MoveHistoryService {
 
   public getMoveHistory$(): Observable<Move[]> {
     return this.moveHistory$;
+  }
+
+  public showMoveHistory() {
+    this.showMoveHistory$$.next(true);
+  }
+
+  public hideMoveHistory() {
+    this.showMoveHistory$$.next(false);
   }
 }


### PR DESCRIPTION
* move history can now be hidden via menu

![grafik](https://user-images.githubusercontent.com/25728708/197409453-a5fa1e06-48b5-4430-9105-238f245f60cc.png)

![grafik](https://user-images.githubusercontent.com/25728708/197409481-39bbf1ba-b3b5-45c3-89ed-8ab0a4ffa245.png)

