### PR TITLE
83-linebreak-in-history-between-piece-symbol-and-coordinate

### DIFF
--- a/angular-chess/src/app/components/move-history/move-history.component.scss
+++ b/angular-chess/src/app/components/move-history/move-history.component.scss
@@ -5,4 +5,5 @@ ul {
 
 .chess-motif {
   font-family: "Chess Motif";
+  display: contents;
 }


### PR DESCRIPTION
* chess pieces in history are now rendered with no box (display:contents)