### PR TITLE
87-wrong-move-numbering-after-importing-a-pgn

### DIFF
--- a/angular-chess/src/app/components/move-history/move-history.component.html
+++ b/angular-chess/src/app/components/move-history/move-history.component.html
@@ -26,7 +26,7 @@
       [pContextMenuRow]="fullMove"
     >
 
-      <td>{{this.boardService.getMoveCount() + fullMove?.count}}</td>
+      <td>{{fullMove?.count}}</td>
       <td>
         <div class="chess-motif">{{getPieceChar(fullMove?.whiteMove)}}</div>
         {{getMoveRepresentation(fullMove?.whiteMove)}}


### PR DESCRIPTION
* moveCount from boardService is no longer used for moveCount computation